### PR TITLE
Add an example and CI

### DIFF
--- a/.github/workflows/astyle.yml
+++ b/.github/workflows/astyle.yml
@@ -1,0 +1,21 @@
+name: Astyle Check
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Astyle check
+        id: Astyle
+        uses: stm32duino/actions/astyle-check@master
+      # Use the output from the `Astyle` step
+      - name: Astyle Errors
+        if: failure()
+        run: |
+          cat ${{ steps.Astyle.outputs.astyle-result }}
+          exit 1

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,24 @@
+name: Compile Examples
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        fqbn:
+          - STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_L476RG
+          # - STMicroelectronics:stm32:Disco:pnum=B_U585I_IOT02A
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: arduino/compile-sketches@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fqbn: ${{ matrix.fqbn }}
+          platforms: |
+            - source-url: https://github.com/stm32duino/BoardManagerFiles/raw/master/package_stmicroelectronics_index.json
+              name: STMicroelectronics:stm32

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,16 @@
+name: Spell Check
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Spell check
+        uses: arduino/actions/libraries/spell-check@master
+        # with:
+        #   ignore-words-list: ./extras/codespell-ignore-words-list.txt

--- a/examples/IIS2MDC_DataLog_Terminal/IIS2MDC_DataLog_Terminal.ino
+++ b/examples/IIS2MDC_DataLog_Terminal/IIS2MDC_DataLog_Terminal.ino
@@ -1,0 +1,71 @@
+/*
+   @file    IIS2MDC_DataLogTerminal.ino
+   @author  Frederic Pillon <frederic.pillon@st.com>
+   @brief   Example to use the IIS2MDC high-performance 3-axis magnetometer
+ *******************************************************************************
+   Copyright (c) 2021, STMicroelectronics
+   All rights reserved.
+
+   This software component is licensed by ST under BSD 3-Clause license,
+   the "License"; You may not use this file except in compliance with the
+   License. You may obtain a copy of the License at:
+                          opensource.org/licenses/BSD-3-Clause
+
+ *******************************************************************************
+*/
+
+
+// Includes
+#include <IIS2MDCSensor.h>
+
+#define SerialPort  Serial
+
+#if defined(ARDUINO_B_U585I_IOT02A)
+#define IIS2MDC_I2C_SCL     PH4
+#define IIS2MDC_I2C_SDA     PH5
+#else
+// Uncomment to set I2C pins to use else default instance will be used
+// #define IIS2MDC_I2C_SCL  PYn
+// #define IIS2MDC_I2C_SDA  PYn
+#endif
+#if defined(IIS2MDC_I2C_SCL) && defined(IIS2MDC_I2C_SDA)
+TwoWire dev_i2c(IIS2MDC_I2C_SDA, IIS2MDC_I2C_SCL);
+#else
+// X-NUCLEO-IKS02A1 uses default instance
+#define dev_i2c       Wire
+#endif
+
+IIS2MDCSensor Magneto(&dev_i2c);
+
+void setup() {
+  // Led
+  pinMode(LED_BUILTIN, OUTPUT);
+  // Initialize serial for output
+  SerialPort.begin(9600);
+
+  // Initialize bus interface
+  dev_i2c.begin();
+
+  // Initlialize component
+  Magneto.begin();
+  Magneto.Enable();
+}
+
+void loop() {
+  // Led blinking
+  digitalWrite(LED_BUILTIN, HIGH);
+  delay(250);
+  digitalWrite(LED_BUILTIN, LOW);
+  delay(250);
+
+  // Read magnetometer
+  int32_t magnetometer[3];
+  Magneto.GetAxes(magnetometer);
+
+  SerialPort.print("Mag[mGauss]:");
+  Serial.print(magnetometer[0]);
+  Serial.print(", ");
+  Serial.print(magnetometer[1]);
+  Serial.print(", ");
+  Serial.println(magnetometer[2]);
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=STM32duino IIS2MDC
-version=2.0.0
+version=2.0.1
 author=SRA
 maintainer=stm32duino
 sentence=Ultra Low Power 3D magnetometer.

--- a/src/IIS2MDCSensor.cpp
+++ b/src/IIS2MDCSensor.cpp
@@ -63,26 +63,22 @@ IIS2MDCSensor::IIS2MDCSensor(TwoWire *i2c) : dev_i2c(i2c)
 IIS2MDCStatusTypeDef IIS2MDCSensor::begin()
 {
   /* Enable BDU */
-  if (iis2mdc_block_data_update_set(&(reg_ctx), PROPERTY_ENABLE) != IIS2MDC_OK)
-  {
+  if (iis2mdc_block_data_update_set(&(reg_ctx), PROPERTY_ENABLE) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
   /* Operating mode selection - power down */
-  if (iis2mdc_operating_mode_set(&(reg_ctx), IIS2MDC_POWER_DOWN) != IIS2MDC_OK)
-  {
+  if (iis2mdc_operating_mode_set(&(reg_ctx), IIS2MDC_POWER_DOWN) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
   /* Output data rate selection */
-  if (iis2mdc_data_rate_set(&(reg_ctx), IIS2MDC_ODR_100Hz) != IIS2MDC_OK)
-  {
+  if (iis2mdc_data_rate_set(&(reg_ctx), IIS2MDC_ODR_100Hz) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
   /* Self Test disabled. */
-  if (iis2mdc_self_test_set(&(reg_ctx), PROPERTY_DISABLE) != IIS2MDC_OK)
-  {
+  if (iis2mdc_self_test_set(&(reg_ctx), PROPERTY_DISABLE) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
@@ -98,8 +94,7 @@ IIS2MDCStatusTypeDef IIS2MDCSensor::begin()
 IIS2MDCStatusTypeDef IIS2MDCSensor::end()
 {
   /* Disable mag */
-  if (Disable() != IIS2MDC_OK)
-  {
+  if (Disable() != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
@@ -113,8 +108,7 @@ IIS2MDCStatusTypeDef IIS2MDCSensor::end()
  */
 IIS2MDCStatusTypeDef IIS2MDCSensor::ReadID(uint8_t *Id)
 {
-  if (iis2mdc_device_id_get(&reg_ctx, Id) != IIS2MDC_OK)
-  {
+  if (iis2mdc_device_id_get(&reg_ctx, Id) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
@@ -129,14 +123,12 @@ IIS2MDCStatusTypeDef IIS2MDCSensor::ReadID(uint8_t *Id)
 IIS2MDCStatusTypeDef IIS2MDCSensor::Enable()
 {
   /* Check if the component is already enabled */
-  if (mag_is_enabled == 1U)
-  {
+  if (mag_is_enabled == 1U) {
     return IIS2MDC_OK;
   }
 
   /* Output data rate selection. */
-  if (iis2mdc_operating_mode_set(&reg_ctx, IIS2MDC_CONTINUOUS_MODE) != IIS2MDC_OK)
-  {
+  if (iis2mdc_operating_mode_set(&reg_ctx, IIS2MDC_CONTINUOUS_MODE) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
@@ -152,14 +144,12 @@ IIS2MDCStatusTypeDef IIS2MDCSensor::Enable()
 IIS2MDCStatusTypeDef IIS2MDCSensor::Disable()
 {
   /* Check if the component is already disabled */
-  if (mag_is_enabled == 0U)
-  {
+  if (mag_is_enabled == 0U) {
     return IIS2MDC_OK;
   }
 
   /* Output data rate selection - power down. */
-  if (iis2mdc_operating_mode_set(&reg_ctx, IIS2MDC_POWER_DOWN) != IIS2MDC_OK)
-  {
+  if (iis2mdc_operating_mode_set(&reg_ctx, IIS2MDC_POWER_DOWN) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
@@ -191,13 +181,11 @@ IIS2MDCStatusTypeDef IIS2MDCSensor::GetOutputDataRate(float *Odr)
   iis2mdc_odr_t odr_low_level;
 
   /* Get current output data rate. */
-  if (iis2mdc_data_rate_get(&reg_ctx, &odr_low_level) != IIS2MDC_OK)
-  {
+  if (iis2mdc_data_rate_get(&reg_ctx, &odr_low_level) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
-  switch (odr_low_level)
-  {
+  switch (odr_low_level) {
     case IIS2MDC_ODR_10Hz:
       *Odr = 10.0f;
       break;
@@ -236,8 +224,7 @@ IIS2MDCStatusTypeDef IIS2MDCSensor::SetOutputDataRate(float Odr)
             : (Odr <= 50.000f) ? IIS2MDC_ODR_50Hz
             :                    IIS2MDC_ODR_100Hz;
 
-  if (iis2mdc_data_rate_set(&reg_ctx, new_odr) != IIS2MDC_OK)
-  {
+  if (iis2mdc_data_rate_set(&reg_ctx, new_odr) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
@@ -278,8 +265,7 @@ IIS2MDCStatusTypeDef IIS2MDCSensor::GetAxes(int32_t *MagneticField)
   float sensitivity;
 
   /* Read raw data values. */
-  if (iis2mdc_magnetic_raw_get(&reg_ctx, data_raw.u8bit) != IIS2MDC_OK)
-  {
+  if (iis2mdc_magnetic_raw_get(&reg_ctx, data_raw.u8bit) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
@@ -304,8 +290,7 @@ IIS2MDCStatusTypeDef IIS2MDCSensor::GetAxesRaw(int16_t *Value)
   axis3bit16_t data_raw;
 
   /* Read raw data values. */
-  if (iis2mdc_magnetic_raw_get(&reg_ctx, data_raw.u8bit) != IIS2MDC_OK)
-  {
+  if (iis2mdc_magnetic_raw_get(&reg_ctx, data_raw.u8bit) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
@@ -325,8 +310,7 @@ IIS2MDCStatusTypeDef IIS2MDCSensor::GetAxesRaw(int16_t *Value)
  */
 IIS2MDCStatusTypeDef IIS2MDCSensor::ReadReg(uint8_t Reg, uint8_t *Data)
 {
-  if (iis2mdc_read_reg(&reg_ctx, Reg, Data, 1) != IIS2MDC_OK)
-  {
+  if (iis2mdc_read_reg(&reg_ctx, Reg, Data, 1) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
@@ -342,8 +326,7 @@ IIS2MDCStatusTypeDef IIS2MDCSensor::ReadReg(uint8_t Reg, uint8_t *Data)
  */
 IIS2MDCStatusTypeDef IIS2MDCSensor::WriteReg(uint8_t Reg, uint8_t Data)
 {
-  if (iis2mdc_write_reg(&reg_ctx, Reg, &Data, 1) != IIS2MDC_OK)
-  {
+  if (iis2mdc_write_reg(&reg_ctx, Reg, &Data, 1) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
@@ -357,8 +340,7 @@ IIS2MDCStatusTypeDef IIS2MDCSensor::WriteReg(uint8_t Reg, uint8_t Data)
  */
 IIS2MDCStatusTypeDef IIS2MDCSensor::SetSelfTest(uint8_t val)
 {
-  if (iis2mdc_self_test_set(&reg_ctx, val) != IIS2MDC_OK)
-  {
+  if (iis2mdc_self_test_set(&reg_ctx, val) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 
@@ -373,8 +355,7 @@ IIS2MDCStatusTypeDef IIS2MDCSensor::SetSelfTest(uint8_t val)
  */
 IIS2MDCStatusTypeDef IIS2MDCSensor::GetDRDYStatus(uint8_t *Status)
 {
-  if (iis2mdc_mag_data_ready_get(&reg_ctx, Status) != IIS2MDC_OK)
-  {
+  if (iis2mdc_mag_data_ready_get(&reg_ctx, Status) != IIS2MDC_OK) {
     return IIS2MDC_ERROR;
   }
 

--- a/src/IIS2MDCSensor.h
+++ b/src/IIS2MDCSensor.h
@@ -54,21 +54,18 @@
 
 /* Typedefs ------------------------------------------------------------------*/
 
-typedef enum
-{
+typedef enum {
   IIS2MDC_OK = 0,
-  IIS2MDC_ERROR =-1
+  IIS2MDC_ERROR = -1
 } IIS2MDCStatusTypeDef;
 
-typedef struct
-{
+typedef struct {
   int16_t x;
   int16_t y;
   int16_t z;
 } IIS2MDC_AxesRaw_t;
 
-typedef struct
-{
+typedef struct {
   int32_t x;
   int32_t y;
   int32_t z;
@@ -76,13 +73,12 @@ typedef struct
 
 
 /* Class Declaration ---------------------------------------------------------*/
-   
+
 /**
  * Abstract class of an IIS2MDC Inertial Measurement Unit (IMU) 3 axes
  * sensor.
  */
-class IIS2MDCSensor
-{
+class IIS2MDCSensor {
   public:
     IIS2MDCSensor(TwoWire *i2c);
     IIS2MDCStatusTypeDef begin();
@@ -92,16 +88,16 @@ class IIS2MDCSensor
     IIS2MDCStatusTypeDef Disable();
     IIS2MDCStatusTypeDef GetSensitivity(float *sensitivity);
     IIS2MDCStatusTypeDef GetOutputDataRate(float *odr);
-	IIS2MDCStatusTypeDef SetOutputDataRate(float odr);
-	IIS2MDCStatusTypeDef GetFullScale(int32_t *fullscale);
-	IIS2MDCStatusTypeDef SetFullScale(int32_t fullscale);
-	IIS2MDCStatusTypeDef GetAxes(int32_t *magnetic_field);
-	IIS2MDCStatusTypeDef GetAxesRaw(int16_t *value);
-	IIS2MDCStatusTypeDef ReadReg(uint8_t reg, uint8_t *data);
-	IIS2MDCStatusTypeDef WriteReg(uint8_t reg, uint8_t data);
-	IIS2MDCStatusTypeDef SetSelfTest(uint8_t val);
-	IIS2MDCStatusTypeDef GetDRDYStatus(uint8_t *status);
-    
+    IIS2MDCStatusTypeDef SetOutputDataRate(float odr);
+    IIS2MDCStatusTypeDef GetFullScale(int32_t *fullscale);
+    IIS2MDCStatusTypeDef SetFullScale(int32_t fullscale);
+    IIS2MDCStatusTypeDef GetAxes(int32_t *magnetic_field);
+    IIS2MDCStatusTypeDef GetAxesRaw(int16_t *value);
+    IIS2MDCStatusTypeDef ReadReg(uint8_t reg, uint8_t *data);
+    IIS2MDCStatusTypeDef WriteReg(uint8_t reg, uint8_t data);
+    IIS2MDCStatusTypeDef SetSelfTest(uint8_t val);
+    IIS2MDCStatusTypeDef GetDRDYStatus(uint8_t *status);
+
     /**
      * @brief Utility function to read data.
      * @param  pBuffer: pointer to data to be read.
@@ -109,7 +105,7 @@ class IIS2MDCSensor
      * @param  NumByteToRead: number of bytes to be read.
      * @retval 0 if ok, an error code otherwise.
      */
-    uint8_t IO_Read(uint8_t* pBuffer, uint8_t RegisterAddr, uint16_t NumByteToRead)
+    uint8_t IO_Read(uint8_t *pBuffer, uint8_t RegisterAddr, uint16_t NumByteToRead)
     {
       if (dev_i2c) {
         dev_i2c->beginTransmission(((uint8_t)(((address) >> 1) & 0x7F)));
@@ -118,7 +114,7 @@ class IIS2MDCSensor
 
         dev_i2c->requestFrom(((uint8_t)(((address) >> 1) & 0x7F)), (uint8_t) NumByteToRead);
 
-        int i=0;
+        int i = 0;
         while (dev_i2c->available()) {
           pBuffer[i] = dev_i2c->read();
           i++;
@@ -129,7 +125,7 @@ class IIS2MDCSensor
 
       return 1;
     }
-    
+
     /**
      * @brief Utility function to write data.
      * @param  pBuffer: pointer to data to be written.
@@ -137,7 +133,7 @@ class IIS2MDCSensor
      * @param  NumByteToWrite: number of bytes to write.
      * @retval 0 if ok, an error code otherwise.
      */
-    uint8_t IO_Write(uint8_t* pBuffer, uint8_t RegisterAddr, uint16_t NumByteToWrite)
+    uint8_t IO_Write(uint8_t *pBuffer, uint8_t RegisterAddr, uint16_t NumByteToWrite)
     {
       if (dev_i2c) {
         dev_i2c->beginTransmission(((uint8_t)(((address) >> 1) & 0x7F)));
@@ -159,23 +155,23 @@ class IIS2MDCSensor
 
     /* Helper classes. */
     TwoWire *dev_i2c;
-    
+
     /* Configuration */
     uint8_t address;
-    
+
     uint8_t mag_is_enabled;
-    
+
     iis2mdc_ctx_t reg_ctx;
-    
+
 };
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-int32_t IIS2MDC_io_write( void *handle, uint8_t WriteAddr, uint8_t *pBuffer, uint16_t nBytesToWrite );
-int32_t IIS2MDC_io_read( void *handle, uint8_t ReadAddr, uint8_t *pBuffer, uint16_t nBytesToRead );
+int32_t IIS2MDC_io_write(void *handle, uint8_t WriteAddr, uint8_t *pBuffer, uint16_t nBytesToWrite);
+int32_t IIS2MDC_io_read(void *handle, uint8_t ReadAddr, uint8_t *pBuffer, uint16_t nBytesToRead);
 #ifdef __cplusplus
-  }
+}
 #endif
 
 #endif

--- a/src/iis2mdc_reg.c
+++ b/src/iis2mdc_reg.c
@@ -610,7 +610,7 @@ int32_t iis2mdc_temperature_raw_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
 
 /**
   * @defgroup   IIS2MDC_common
-  * @brief      This section group common usefull functions
+  * @brief      This section group common useful functions
   * @{
   *
   */

--- a/src/iis2mdc_reg.c
+++ b/src/iis2mdc_reg.c
@@ -45,7 +45,7 @@
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_read_reg(iis2mdc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t iis2mdc_read_reg(iis2mdc_ctx_t *ctx, uint8_t reg, uint8_t *data,
                          uint16_t len)
 {
   int32_t ret;
@@ -63,7 +63,7 @@ int32_t iis2mdc_read_reg(iis2mdc_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_write_reg(iis2mdc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t iis2mdc_write_reg(iis2mdc_ctx_t *ctx, uint8_t reg, uint8_t *data,
                           uint16_t len)
 {
   int32_t ret;
@@ -159,10 +159,10 @@ int32_t iis2mdc_operating_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_md_t val)
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.md = (uint8_t)val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -180,7 +180,7 @@ int32_t iis2mdc_operating_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_md_t *val)
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   switch (reg.md) {
     case IIS2MDC_CONTINUOUS_MODE:
       *val = IIS2MDC_CONTINUOUS_MODE;
@@ -211,10 +211,10 @@ int32_t iis2mdc_data_rate_set(iis2mdc_ctx_t *ctx, iis2mdc_odr_t val)
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.odr = (uint8_t)val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -232,7 +232,7 @@ int32_t iis2mdc_data_rate_get(iis2mdc_ctx_t *ctx, iis2mdc_odr_t *val)
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   switch (reg.odr) {
     case IIS2MDC_ODR_10Hz:
       *val = IIS2MDC_ODR_10Hz;
@@ -266,10 +266,10 @@ int32_t iis2mdc_power_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_lp_t val)
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.lp = (uint8_t)val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -287,7 +287,7 @@ int32_t iis2mdc_power_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_lp_t *val)
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   switch (reg.lp) {
     case IIS2MDC_HIGH_RESOLUTION:
       *val = IIS2MDC_HIGH_RESOLUTION;
@@ -315,10 +315,10 @@ int32_t iis2mdc_offset_temp_comp_set(iis2mdc_ctx_t *ctx, uint8_t val)
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.comp_temp_en = val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -336,7 +336,7 @@ int32_t iis2mdc_offset_temp_comp_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   *val = reg.comp_temp_en;
 
   return ret;
@@ -356,10 +356,10 @@ int32_t iis2mdc_low_pass_bandwidth_set(iis2mdc_ctx_t *ctx,
   iis2mdc_cfg_reg_b_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.lpf = (uint8_t)val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -378,7 +378,7 @@ int32_t iis2mdc_low_pass_bandwidth_get(iis2mdc_ctx_t *ctx,
   iis2mdc_cfg_reg_b_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t *) &reg, 1);
   switch (reg.lpf) {
     case IIS2MDC_ODR_DIV_2:
       *val = IIS2MDC_ODR_DIV_2;
@@ -407,10 +407,10 @@ int32_t iis2mdc_set_rst_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_set_rst_t val)
   iis2mdc_cfg_reg_b_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.set_rst = (uint8_t)val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -428,7 +428,7 @@ int32_t iis2mdc_set_rst_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_set_rst_t *val)
   iis2mdc_cfg_reg_b_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t *) &reg, 1);
   switch (reg.set_rst) {
     case IIS2MDC_SET_SENS_ODR_DIV_63:
       *val = IIS2MDC_SET_SENS_ODR_DIV_63;
@@ -464,10 +464,10 @@ int32_t iis2mdc_set_rst_sensor_single_set(iis2mdc_ctx_t *ctx, uint8_t val)
   iis2mdc_cfg_reg_b_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.off_canc_one_shot = val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -489,7 +489,7 @@ int32_t iis2mdc_set_rst_sensor_single_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   iis2mdc_cfg_reg_b_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t *) &reg, 1);
   *val = reg.off_canc_one_shot;
 
   return ret;
@@ -508,10 +508,10 @@ int32_t iis2mdc_block_data_update_set(iis2mdc_ctx_t *ctx, uint8_t val)
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.bdu = val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -529,7 +529,7 @@ int32_t iis2mdc_block_data_update_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   *val = reg.bdu;
 
   return ret;
@@ -548,7 +548,7 @@ int32_t iis2mdc_mag_data_ready_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   iis2mdc_status_reg_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_STATUS_REG, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_STATUS_REG, (uint8_t *) &reg, 1);
   *val = reg.zyxda;
 
   return ret;
@@ -567,7 +567,7 @@ int32_t iis2mdc_mag_data_ovr_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   iis2mdc_status_reg_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_STATUS_REG, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_STATUS_REG, (uint8_t *) &reg, 1);
   *val = reg.zyxor;
 
   return ret;
@@ -644,10 +644,10 @@ int32_t iis2mdc_reset_set(iis2mdc_ctx_t *ctx, uint8_t val)
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.soft_rst = val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -665,7 +665,7 @@ int32_t iis2mdc_reset_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   *val = reg.soft_rst;
 
   return ret;
@@ -684,10 +684,10 @@ int32_t iis2mdc_boot_set(iis2mdc_ctx_t *ctx, uint8_t val)
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.reboot = val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -705,7 +705,7 @@ int32_t iis2mdc_boot_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t *) &reg, 1);
   *val = reg.reboot;
 
   return ret;
@@ -724,10 +724,10 @@ int32_t iis2mdc_self_test_set(iis2mdc_ctx_t *ctx, uint8_t val)
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.self_test = val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -745,7 +745,7 @@ int32_t iis2mdc_self_test_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   *val = reg.self_test;
 
   return ret;
@@ -764,10 +764,10 @@ int32_t iis2mdc_data_format_set(iis2mdc_ctx_t *ctx, iis2mdc_ble_t val)
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.ble = (uint8_t)val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -785,7 +785,7 @@ int32_t iis2mdc_data_format_get(iis2mdc_ctx_t *ctx, iis2mdc_ble_t *val)
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   switch (reg.ble) {
     case IIS2MDC_LSB_AT_LOW_ADD:
       *val = IIS2MDC_LSB_AT_LOW_ADD;
@@ -811,7 +811,7 @@ int32_t iis2mdc_data_format_get(iis2mdc_ctx_t *ctx, iis2mdc_ble_t *val)
 int32_t iis2mdc_status_get(iis2mdc_ctx_t *ctx, iis2mdc_status_reg_t *val)
 {
   int32_t ret;
-  ret =  iis2mdc_read_reg(ctx, IIS2MDC_STATUS_REG, (uint8_t*) val, 1);
+  ret =  iis2mdc_read_reg(ctx, IIS2MDC_STATUS_REG, (uint8_t *) val, 1);
   return ret;
 }
 
@@ -844,10 +844,10 @@ int32_t iis2mdc_offset_int_conf_set(iis2mdc_ctx_t *ctx,
   iis2mdc_cfg_reg_b_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.int_on_dataoff = (uint8_t)val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -868,7 +868,7 @@ int32_t iis2mdc_offset_int_conf_get(iis2mdc_ctx_t *ctx,
   iis2mdc_cfg_reg_b_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t *) &reg, 1);
   switch (reg.int_on_dataoff) {
     case IIS2MDC_CHECK_BEFORE:
       *val = IIS2MDC_CHECK_BEFORE;
@@ -896,10 +896,10 @@ int32_t iis2mdc_drdy_on_pin_set(iis2mdc_ctx_t *ctx, uint8_t val)
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.drdy_on_pin = val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -917,7 +917,7 @@ int32_t iis2mdc_drdy_on_pin_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   *val = reg.drdy_on_pin;
 
   return ret;
@@ -936,10 +936,10 @@ int32_t iis2mdc_int_on_pin_set(iis2mdc_ctx_t *ctx, uint8_t val)
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.int_on_pin = val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -957,7 +957,7 @@ int32_t iis2mdc_int_on_pin_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   *val = reg.int_on_pin;
 
   return ret;
@@ -975,7 +975,7 @@ int32_t iis2mdc_int_gen_conf_set(iis2mdc_ctx_t *ctx,
                                  iis2mdc_int_crtl_reg_t *val)
 {
   int32_t ret;
-  ret =  iis2mdc_write_reg(ctx, IIS2MDC_INT_CRTL_REG, (uint8_t*) val, 1);
+  ret =  iis2mdc_write_reg(ctx, IIS2MDC_INT_CRTL_REG, (uint8_t *) val, 1);
   return ret;
 }
 
@@ -991,7 +991,7 @@ int32_t iis2mdc_int_gen_conf_get(iis2mdc_ctx_t *ctx,
                                  iis2mdc_int_crtl_reg_t *val)
 {
   int32_t ret;
-  ret =  iis2mdc_read_reg(ctx, IIS2MDC_INT_CRTL_REG, (uint8_t*) val, 1);
+  ret =  iis2mdc_read_reg(ctx, IIS2MDC_INT_CRTL_REG, (uint8_t *) val, 1);
   return ret;
 }
 
@@ -1007,7 +1007,7 @@ int32_t iis2mdc_int_gen_source_get(iis2mdc_ctx_t *ctx,
                                    iis2mdc_int_source_reg_t *val)
 {
   int32_t ret;
-  ret =  iis2mdc_read_reg(ctx, IIS2MDC_INT_SOURCE_REG, (uint8_t*) val, 1);
+  ret =  iis2mdc_read_reg(ctx, IIS2MDC_INT_SOURCE_REG, (uint8_t *) val, 1);
   return ret;
 }
 
@@ -1071,10 +1071,10 @@ int32_t iis2mdc_i2c_interface_set(iis2mdc_ctx_t *ctx, iis2mdc_i2c_dis_t val)
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   if (ret == 0) {
     reg.i2c_dis = (uint8_t)val;
-    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   }
   return ret;
 }
@@ -1092,7 +1092,7 @@ int32_t iis2mdc_i2c_interface_get(iis2mdc_ctx_t *ctx, iis2mdc_i2c_dis_t *val)
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
 
-  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t *) &reg, 1);
   switch (reg.i2c_dis) {
     case IIS2MDC_I2C_ENABLE:
       *val = IIS2MDC_I2C_ENABLE;

--- a/src/iis2mdc_reg.h
+++ b/src/iis2mdc_reg.h
@@ -23,7 +23,7 @@
 #define IIS2MDC_REGS_H
 
 #ifdef __cplusplus
-  extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -55,22 +55,22 @@
   *
   */
 
-typedef union{
+typedef union {
   int16_t i16bit[3];
   uint8_t u8bit[6];
 } axis3bit16_t;
 
-typedef union{
+typedef union {
   int16_t i16bit;
   uint8_t u8bit[2];
 } axis1bit16_t;
 
-typedef union{
+typedef union {
   int32_t i32bit[3];
   uint8_t u8bit[12];
 } axis3bit32_t;
 
-typedef union{
+typedef union {
   int32_t i32bit;
   uint8_t u8bit[4];
 } axis1bit32_t;
@@ -80,7 +80,7 @@ typedef union{
   *
   */
 
-typedef struct{
+typedef struct {
   uint8_t bit0       : 1;
   uint8_t bit1       : 1;
   uint8_t bit2       : 1;
@@ -104,8 +104,8 @@ typedef struct{
   *
   */
 
-typedef int32_t (*iis2mdc_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*iis2mdc_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*iis2mdc_write_ptr)(void *, uint8_t, uint8_t *, uint16_t);
+typedef int32_t (*iis2mdc_read_ptr)(void *, uint8_t, uint8_t *, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
@@ -126,9 +126,9 @@ typedef struct {
 /** @defgroup    Generic address-data structure definition
   * @brief       This structure is useful to load a predefined configuration
   *              of a sensor.
-	*              You can create a sensor configuration by your own or using 
-	*              Unico / Unicleo tools available on STMicroelectronics
-	*              web site.
+  *              You can create a sensor configuration by your own or using
+  *              Unico / Unicleo tools available on STMicroelectronics
+  *              web site.
   *
   * @{
   *
@@ -273,7 +273,7 @@ typedef struct {
 #define IIS2MDC_TEMP_OUT_L_REG          0x6EU
 #define IIS2MDC_TEMP_OUT_H_REG          0x6FU
 
-typedef union{
+typedef union {
   iis2mdc_cfg_reg_a_t            cfg_reg_a;
   iis2mdc_cfg_reg_b_t            cfg_reg_b;
   iis2mdc_cfg_reg_c_t            cfg_reg_c;
@@ -284,9 +284,9 @@ typedef union{
   uint8_t                        byte;
 } iis2mdc_reg_t;
 
-int32_t iis2mdc_read_reg(iis2mdc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t iis2mdc_read_reg(iis2mdc_ctx_t *ctx, uint8_t reg, uint8_t *data,
                          uint16_t len);
-int32_t iis2mdc_write_reg(iis2mdc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t iis2mdc_write_reg(iis2mdc_ctx_t *ctx, uint8_t reg, uint8_t *data,
                           uint16_t len);
 
 float iis2mdc_from_lsb_to_mgauss(int16_t lsb);


### PR DESCRIPTION
- add IIS2MDC_DataLogTerminal example
- apply astyle source code formatting
- add astyle, spell check and compile examples CI
- fix typo

Note that Compile examples currently disabled as STM32 core version 2.1.0 is required.